### PR TITLE
More verbose notifications when wrong PIN entered.

### DIFF
--- a/src/bin/issuer/silvia_issuer.cpp
+++ b/src/bin/issuer/silvia_issuer.cpp
@@ -200,7 +200,16 @@ bool communicate_with_card(silvia_card_channel* card, std::vector<bytestring>& c
 		
 		if (result.substr(result.size() - 2) != "9000")
 		{
-			printf("(0x%s) ", result.substr(result.size() - 2).hex_str().c_str());
+			// Return values between 63C0--63CF indicate a wrong PIN
+			const unsigned int PIN_attempts = ((result.substr(result.size() - 2) ^ "63C0")[0] << 8) | ((result.substr(result.size() - 2) ^ "63C0")[1]);
+			if (PIN_attempts <= 0xF)
+			{
+				printf("wrong PIN, %u attempts remaining ", PIN_attempts);
+			}
+			else
+			{
+				printf("(0x%s) ", result.substr(result.size() - 2).hex_str().c_str());
+			}
 			comm_ok = false;
 			break;
 		}

--- a/src/bin/verifier/silvia_verifier.cpp
+++ b/src/bin/verifier/silvia_verifier.cpp
@@ -178,7 +178,11 @@ bool verify_pin(silvia_card_channel* card)
 		
 		return true;
 	}
-	else if ((sw >= 0x63C0) && (sw <= 0x63CF))
+	else if (sw == 0x63C0)
+	{
+		printf("FAILED, the card has been blocked (entered wrong PIN too many times)\n");
+	}
+	else if ((sw > 0x63C0) && (sw <= 0x63CF))
 	{
 		printf("FAILED (%u attempts remaining)\n", sw - 0x63C0);
 	}


### PR DESCRIPTION
- silvia_issuer.cpp (`communicate_with_card`): Handled the specific case
  where the return code indicated a wrong PIN.
- silvia_verifier.cpp (`verify_pin`): Added a specific message for a
  blocked card.
