### PR TITLE
Also include some missing headers into make install

### DIFF
--- a/src/lib/common/Makefile.am
+++ b/src/lib/common/Makefile.am
@@ -29,7 +29,8 @@ libsilvia_common_la_LIBADD =
 
 pkginclude_HEADERS =		silvia_types.h \
 				silvia_bytestring.h \
-				silvia_parameters.h
+				silvia_parameters.h \
+				silvia_card_channel.h
 
 if BUILD_TESTS
 SUBDIRS =			test

--- a/src/lib/common/silvia_card_channel.h
+++ b/src/lib/common/silvia_card_channel.h
@@ -35,7 +35,6 @@
 #ifndef _SILVIA_CARD_CHANNEL_H
 #define _SILVIA_CARD_CHANNEL_H
 
-#include "config.h"
 #include <string>
 #include "silvia_bytestring.h"
 

--- a/src/lib/issuer/Makefile.am
+++ b/src/lib/issuer/Makefile.am
@@ -19,7 +19,10 @@ libsilvia_issuer_la_SOURCES =	silvia_issuer_keygen.cpp \
 libsilvia_issuer_la_LIBADD =	
 
 pkginclude_HEADERS =		silvia_issuer.h \
-				silvia_irma_issuer.h
+				silvia_irma_issuer.h \
+				silvia_issuer_keygen.h \
+				silvia_issue_spec.h
+
 
 if BUILD_TESTS
 SUBDIRS =			test

--- a/src/lib/nfc/Makefile.am
+++ b/src/lib/nfc/Makefile.am
@@ -13,6 +13,9 @@ libsilvia_nfc_la_SOURCES =	silvia_nfc_card.h \
 
 libsilvia_nfc_la_LIBADD =	
 
+pkginclude_HEADERS =		silvia_nfc_card.h
+
+
 if BUILD_TESTS
 SUBDIRS =			test
 endif

--- a/src/lib/nfc/silvia_nfc_card.h
+++ b/src/lib/nfc/silvia_nfc_card.h
@@ -32,7 +32,6 @@
  Smart card communication classes
  *****************************************************************************/
  
-#include "config.h"
 #include "silvia_bytestring.h"
 #include "silvia_card_channel.h"
 #include <nfc/nfc.h>

--- a/src/lib/pcsc/Makefile.am
+++ b/src/lib/pcsc/Makefile.am
@@ -13,6 +13,8 @@ libsilvia_pcsc_la_SOURCES =	silvia_pcsc_card.h \
 
 libsilvia_pcsc_la_LIBADD =	
 
+pkginclude_HEADERS =		silvia_pcsc_card.h
+
 if BUILD_TESTS
 SUBDIRS =			test
 endif

--- a/src/lib/pcsc/silvia_pcsc_card.h
+++ b/src/lib/pcsc/silvia_pcsc_card.h
@@ -32,9 +32,8 @@
  Smart card communication classes
  *****************************************************************************/
  
-#include "config.h"
-#include "silvia_bytestring.h"
-#include "silvia_card_channel.h"
+#include <silvia_bytestring.h>
+#include <silvia_card_channel.h>
 #include <PCSC/winscard.h>
 #include <PCSC/wintypes.h>
 #include <memory>


### PR DESCRIPTION
These headers are needed if you want to do anything useful.
Also, the #include "config.h" in these headers has been removed, because otherwise it would not compile for users of the library.
