### PR TITLE
Add '-d' to allowed options in silvia_manager

### DIFF
--- a/src/bin/manager/silvia_manager.cpp
+++ b/src/bin/manager/silvia_manager.cpp
@@ -630,9 +630,9 @@ int main(int argc, char* argv[])
 #endif
 	
 #if defined(WITH_PCSC) && defined(WITH_NFC)
-	while ((c = getopt(argc, argv, "r:caso:lhvPN")) != -1)
+	while ((c = getopt(argc, argv, "r:cdaso:lhvPN")) != -1)
 #else
-	while ((c = getopt(argc, argv, "r:caso:lhv")) != -1)
+	while ((c = getopt(argc, argv, "r:cdaso:lhv")) != -1)
 #endif
 	{
 		switch (c)


### PR DESCRIPTION
Too trivial for words, but the '-d' option wasn't in the getopt list.
