### PR TITLE
Update unit test to conform to pin-entry mechanism change

### DIFF
--- a/src/lib/issuer/test/issuetests.cpp
+++ b/src/lib/issuer/test/issuetests.cpp
@@ -214,15 +214,13 @@ void issue_tests::test_irma_issuer()
 	
 	silvia_irma_issuer issuer(&pubkey, &privkey, &ispec);
 	
-	std::vector<bytestring> commands = issuer.get_select_commands("1234");
+	std::vector<bytestring> commands = issuer.get_select_commands();
 	
-	CPPUNIT_ASSERT(commands.size() == 2);
+	CPPUNIT_ASSERT(commands.size() == 1);
 	
 	CPPUNIT_ASSERT(commands[0] == "00A4040009F849524D416361726400");
-	CPPUNIT_ASSERT(commands[1] == "00200000083132333400000000");
 	
 	std::vector<bytestring> results;
-	results.push_back("9000");
 	results.push_back("9000");
 	
 	CPPUNIT_ASSERT(issuer.submit_select_data(results));


### PR DESCRIPTION
The test failed after the changes in eb830c6fe178c519f81bd4fc4170f495b7d27f30, this should fix it

(well, at least it now passes, I am not yet deep enough into the code to confirm that the test is _right_ :) )
